### PR TITLE
Remove hard coded amd64 from apt repo

### DIFF
--- a/tasks/install_linux_repo.yml
+++ b/tasks/install_linux_repo.yml
@@ -57,7 +57,7 @@
 
     - name: Add Debian/Ubuntu Linux repository
       apt_repository:
-        repo: "deb [arch=amd64] {{ consul_repo_url }} {{ ansible_distribution_release }} main"
+        repo: "deb {{ consul_repo_url }} {{ ansible_distribution_release }} main"
         state: present
         update_cache: true
       when: "ansible_os_family|lower == 'debian'"


### PR DESCRIPTION
This now matches what is set up in ansible-vault